### PR TITLE
StakingVault: audit-driven refactor

### DIFF
--- a/contracts/utils/StakingVault.sol
+++ b/contracts/utils/StakingVault.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title StakingVault
@@ -55,6 +56,7 @@ contract StakingVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
     error StakingVault__ZeroAsset();
     error StakingVault__FeeOnTransferNotSupported();
     error StakingVault__ArrayLengthMismatch();
+    error StakingVault__RenounceOwnershipDisabled();
 
     constructor(IERC20 _asset, string memory _name, string memory _symbol)
         ERC4626(_asset)
@@ -87,6 +89,10 @@ contract StakingVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
 
     function unpause() external onlyOwner {
         _unpause();
+    }
+
+    function renounceOwnership() public view override onlyOwner {
+        revert StakingVault__RenounceOwnershipDisabled();
     }
 
     /// @notice Deposit assets, mint shares to caller. Cap-gating is enforced by super.deposit's
@@ -161,7 +167,7 @@ contract StakingVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
 
         uint256 principalOut = balanceBefore == 0
             ? 0
-            : (principalBefore * shares) / balanceBefore;
+            : Math.mulDiv(principalBefore, shares, balanceBefore);
         uint256 newPrincipal = principalBefore - principalOut;
         depositedPrincipal[owner] = newPrincipal;
         emit DepositorWhitelisted(owner, depositCap[owner], newPrincipal);
@@ -184,7 +190,7 @@ contract StakingVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
 
         uint256 principalOut = balanceBefore == 0
             ? 0
-            : (principalBefore * shares) / balanceBefore;
+            : Math.mulDiv(principalBefore, shares, balanceBefore);
         uint256 newPrincipal = principalBefore - principalOut;
         depositedPrincipal[owner] = newPrincipal;
         emit DepositorWhitelisted(owner, depositCap[owner], newPrincipal);

--- a/contracts/utils/StakingVault.sol
+++ b/contracts/utils/StakingVault.sol
@@ -3,107 +3,222 @@ pragma solidity ^0.8.28;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
 
 /**
  * @title StakingVault
- * @notice A basic ERC4626 vault with whitelist allowing only whitelisted depositors to enter the vault
- * @dev Extends OpenZeppelin's ERC4626 implementation with additional access control features
+ * @notice Whitelisted ERC4626 reimbursement vault. Each whitelisted user has a per-address
+ *         `depositCap` representing the maximum *principal* (raw asset units deposited)
+ *         they may have in the vault at any time. Users may freely redeem and re-deposit
+ *         provided their currently-deposited principal stays at or below their cap.
+ *
+ *         The protocol team reimburses users by directly transferring asset tokens to this
+ *         vault (e.g., `IERC20(asset()).transfer(stakingVault, amount)`); this increases
+ *         `totalAssets()` and therefore the per-share asset value without minting new shares,
+ *         so existing depositors withdraw more assets than they originally deposited.
+ *
+ *         Shares are *soulbound* — `transfer` and `transferFrom` revert. Allowance is still
+ *         usable via `redeem`/`withdraw` (OZ `_spendAllowance` runs before `_burn`, which is
+ *         exempted from the transfer restriction because its `to` is the zero address).
+ *
+ *         Vault share decimals = `asset.decimals() + 6` (per `_decimalsOffset()`), as a
+ *         defence against the first-depositor share-inflation attack. Operators integrating
+ *         with wallets/explorers that assume 18 decimals must account for this.
+ *
+ * @dev Cap-restoration on redeem decouples from asset availability: an under-reimbursed
+ *      vault will distribute available assets proportionally (ERC4626 default), but each
+ *      user's cap-room is restored proportional to *shares burned*, not assets received.
+ *      Rationale: a temporarily-underfunded vault must not permanently consume users'
+ *      deposit allowance.
  */
-contract StakingVault is ERC4626, Ownable {
+contract StakingVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
 
-    /// @notice user => amount underlying asset they can deposit
-    mapping(address => uint256) public depositWhitelist;
+    /// @notice user => maximum principal that may be deposited at any time
+    mapping(address => uint256) public depositCap;
 
-    /// @notice Emitted when a depositor is added to the whitelist
-    event DepositorWhitelisted(address indexed depositor, uint256 amount);
+    /// @notice user => currently-deposited principal (raw asset units, excludes yield)
+    mapping(address => uint256) public depositedPrincipal;
 
-    /**
-     * @notice Initializes the StakingVault contract
-     * @param _asset The underlying ERC20 asset for the vault
-     * @param _name The name of the vault token
-     * @param _symbol The symbol of the vault token
-     */
+    /// @notice Emitted when an owner sets / updates a depositor's cap, or when principal changes
+    ///         via deposit/mint/redeem/withdraw. Off-chain consumers can derive `maxDeposit`
+    ///         from `(cap, currentPrincipal)` without replaying transfer logs.
+    event DepositorWhitelisted(address indexed depositor, uint256 cap, uint256 currentPrincipal);
+
+    error StakingVault__ReceiverMismatch(address expected, address actual);
+    error StakingVault__NonTransferable();
+    error StakingVault__ZeroAddress();
+    error StakingVault__ZeroAsset();
+    error StakingVault__FeeOnTransferNotSupported();
+    error StakingVault__ArrayLengthMismatch();
+
     constructor(IERC20 _asset, string memory _name, string memory _symbol)
         ERC4626(_asset)
         ERC20(_name, _symbol)
         Ownable(msg.sender)
-    {}
+    {
+        if (address(_asset) == address(0)) revert StakingVault__ZeroAsset();
+    }
 
-    /**
-     * @notice Adds multiple addresses to the deposit whitelist with max yield limits
-     * @param depositors Array of addresses to whitelist
-     * @param depositAmounts Array of maximum deposit amounts for each depositor
-     */
+    /// @notice Sets the deposit cap (max principal in vault) for each address. Overwrites prior cap.
+    /// @dev    Cap may be set below `depositedPrincipal[user]` — existing principal is grandfathered;
+    ///         `maxDeposit` saturates to 0 until the user redeems below the new cap.
+    ///         Duplicates in `depositors` last-write-wins; operator responsibility.
     function setDepositorsWhitelistDepositAmounts(address[] calldata depositors, uint256[] calldata depositAmounts)
         external
         onlyOwner
     {
-        require(depositors.length == depositAmounts.length, "Array length mismatch");
+        if (depositors.length != depositAmounts.length) revert StakingVault__ArrayLengthMismatch();
         for (uint256 i = 0; i < depositors.length; i++) {
-            depositWhitelist[depositors[i]] = depositAmounts[i];
-            emit DepositorWhitelisted(depositors[i], depositAmounts[i]);
+            address depositor = depositors[i];
+            if (depositor == address(0)) revert StakingVault__ZeroAddress();
+            depositCap[depositor] = depositAmounts[i];
+            emit DepositorWhitelisted(depositor, depositAmounts[i], depositedPrincipal[depositor]);
         }
     }
 
-    /**
-     * @notice Override deposit to enforce whitelist
-     * @param assets The amount of assets to deposit
-     * @param receiver The address to receive the shares
-     */
-    function deposit(uint256 assets, address receiver) public virtual override returns (uint256) {
-        depositWhitelist[msg.sender] -= assets;
-        return super.deposit(assets, receiver);
+    function pause() external onlyOwner {
+        _pause();
     }
 
-    /**
-     * @notice Override mint to enforce whitelist
-     * @param shares The amount of shares to mint
-     * @param receiver The address to receive the shares
-     */
-    function mint(uint256 shares, address receiver) public virtual override returns (uint256) {
-        uint256 assets = previewMint(shares);
-        depositWhitelist[msg.sender] -= assets;
-        return super.mint(shares, receiver);
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
-    /**
-     * @notice Override redeem to enforce yield limits
-     * @param shares The amount of shares to redeem
-     * @param receiver The address to receive the assets
-     * @param owner The address that owns the shares
-     */
-    function redeem(uint256 shares, address receiver, address owner) public virtual override returns (uint256 assets) {
-        assets = previewRedeem(shares);
-        depositWhitelist[owner] += assets;
+    /// @notice Deposit assets, mint shares to caller. Cap-gating is enforced by super.deposit's
+    ///         `maxDeposit(receiver)` check (our override returns remaining cap-room or 0 if paused).
+    /// @dev    Principal mutation is DEFERRED until AFTER super.deposit succeeds. Mutating before
+    ///         super would cause super's internal `maxDeposit(receiver)` check to see the
+    ///         post-mutation state (P + assets), spuriously reverting any deposit > half remaining.
+    ///         `nonReentrant` is the load-bearing protection against ERC777-style callback reentry;
+    ///         the deferred-mutation order is defense-in-depth for the cross-direction reentrancy
+    ///         class only — same-direction (deposit→deposit) requires `nonReentrant`.
+    function deposit(uint256 assets, address receiver)
+        public
+        override
+        nonReentrant
+        whenNotPaused
+        returns (uint256)
+    {
+        if (receiver != msg.sender) revert StakingVault__ReceiverMismatch(msg.sender, receiver);
 
-        // Call parent with potentially adjusted assets
-        // We need to burn the shares and transfer the capped assets
-        if (msg.sender != owner) {
-            _spendAllowance(owner, msg.sender, shares);
-        }
+        uint256 balanceBefore = IERC20(asset()).balanceOf(address(this));
+        uint256 shares = super.deposit(assets, receiver);
+        uint256 balanceAfter = IERC20(asset()).balanceOf(address(this));
+        if (balanceAfter - balanceBefore != assets) revert StakingVault__FeeOnTransferNotSupported();
 
-        _burn(owner, shares);
-        IERC20(asset()).safeTransfer(receiver, assets);
-
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        uint256 newPrincipal = depositedPrincipal[msg.sender] + assets;
+        depositedPrincipal[msg.sender] = newPrincipal;
+        emit DepositorWhitelisted(msg.sender, depositCap[msg.sender], newPrincipal);
+        return shares;
     }
 
-    /**
-     * @notice Override withdraw to enforce yield limits
-     * @param assets The amount of assets to withdraw
-     * @param receiver The address to receive the assets
-     * @param owner The address that owns the shares
-     */
+    /// @notice Mint shares to caller. Cap-gating is enforced by super.mint's `maxMint(receiver)` check.
+    /// @dev    Same ordering rationale as `deposit`. `super.mint` returns the asset amount it
+    ///         charged (== previewMint(shares)); we debit principal by that exact amount.
+    function mint(uint256 shares, address receiver)
+        public
+        override
+        nonReentrant
+        whenNotPaused
+        returns (uint256)
+    {
+        if (receiver != msg.sender) revert StakingVault__ReceiverMismatch(msg.sender, receiver);
+
+        uint256 balanceBefore = IERC20(asset()).balanceOf(address(this));
+        uint256 assets = super.mint(shares, receiver);
+        uint256 balanceAfter = IERC20(asset()).balanceOf(address(this));
+        if (balanceAfter - balanceBefore != assets) revert StakingVault__FeeOnTransferNotSupported();
+
+        uint256 newPrincipal = depositedPrincipal[msg.sender] + assets;
+        depositedPrincipal[msg.sender] = newPrincipal;
+        emit DepositorWhitelisted(msg.sender, depositCap[msg.sender], newPrincipal);
+        return assets;
+    }
+
+    /// @notice Redeem shares for assets. NOT pause-gated — exits remain available at the vault layer.
+    /// @dev    Snapshot `principalBefore` and `balanceBefore` BEFORE super.redeem, because super
+    ///         burns shares (mutating `balanceOf(owner)`). Reading `balanceOf(owner)` after super
+    ///         would yield post-burn balance, causing:
+    ///         - full-redeem: balanceOf=0 → division by zero → DoS
+    ///         - partial-redeem: divisor shrinks → over-credit (drains entire principal)
+    ///         Cap restoration is proportional to shares burned, independent of assets received
+    ///         (cap-room decouples from asset shortfall — see contract NatSpec).
+    function redeem(uint256 shares, address receiver, address owner)
+        public
+        override
+        nonReentrant
+        returns (uint256 assets)
+    {
+        uint256 principalBefore = depositedPrincipal[owner];
+        uint256 balanceBefore = balanceOf(owner);
+
+        assets = super.redeem(shares, receiver, owner);
+
+        uint256 principalOut = balanceBefore == 0
+            ? 0
+            : (principalBefore * shares) / balanceBefore;
+        uint256 newPrincipal = principalBefore - principalOut;
+        depositedPrincipal[owner] = newPrincipal;
+        emit DepositorWhitelisted(owner, depositCap[owner], newPrincipal);
+    }
+
+    /// @notice Withdraw a specified asset amount, burning the necessary shares. NOT pause-gated.
+    /// @dev    See `redeem` for snapshot rationale. Uses ceil-rounded share count (returned by
+    ///         super.withdraw, matching what was burned); may credit principalOut up to 1 wei
+    ///         more than strict proportional fairness — acceptable, in user's favor.
     function withdraw(uint256 assets, address receiver, address owner)
         public
-        virtual
         override
+        nonReentrant
         returns (uint256 shares)
     {
-        shares = previewWithdraw(assets);
-        redeem(shares, receiver, owner);
+        uint256 principalBefore = depositedPrincipal[owner];
+        uint256 balanceBefore = balanceOf(owner);
+
+        shares = super.withdraw(assets, receiver, owner);
+
+        uint256 principalOut = balanceBefore == 0
+            ? 0
+            : (principalBefore * shares) / balanceBefore;
+        uint256 newPrincipal = principalBefore - principalOut;
+        depositedPrincipal[owner] = newPrincipal;
+        emit DepositorWhitelisted(owner, depositCap[owner], newPrincipal);
     }
+
+    /// @notice Returns remaining deposit capacity for `receiver`. Reflects pause state.
+    function maxDeposit(address receiver) public view override returns (uint256) {
+        if (paused()) return 0;
+        uint256 cap = depositCap[receiver];
+        uint256 principal = depositedPrincipal[receiver];
+        return cap > principal ? cap - principal : 0;
+    }
+
+    /// @notice Returns max shares mintable for `receiver`. Round-trip safe with `super.mint` cap check
+    ///         (proof: `previewMint(previewDeposit(X)) ≤ X` for any X under floor/ceil rounding).
+    function maxMint(address receiver) public view override returns (uint256) {
+        if (paused()) return 0;
+        return previewDeposit(maxDeposit(receiver));
+    }
+
+    /// @notice Returns 6. Adds 6 decimals of virtual-share offset to harden against
+    ///         first-depositor inflation attacks (raises attacker cost by ~10^6×).
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return 6;
+    }
+
+    /// @notice Soulbound: reject all transfers between non-zero addresses. Mint (`from==0`)
+    ///         and burn (`to==0`) are permitted so super's internal share movements work.
+    /// @dev    `allowance` and `approve` remain functional because they don't call `_update`;
+    ///         allowance is only spendable via `redeem`/`withdraw` (which burn via `to==0`).
+    ///         Direct `transferFrom` reverts via this guard.
+    function _update(address from, address to, uint256 value) internal override {
+        if (from != address(0) && to != address(0)) revert StakingVault__NonTransferable();
+        super._update(from, to, value);
+    }
+
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,7 +17,10 @@ remappings = [
     "v2-periphery/=test/invariant/modules/uniswap-v2/v2-periphery/contracts/",
     "uniswap-v2/=test/invariant/modules/uniswap-v2/",
     "solidity-bytes-utils/contracts/=test/invariant/modules/fraxlend/libraries/",
-    "@rari-capital/solmate=node_modules/solmate"
+    "@rari-capital/solmate=node_modules/solmate",
+    "@openzeppelin/contracts@5.0.2/=node_modules/@openzeppelin/contracts-5.0.2/",
+    "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
+    "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/"
 ]
 [etherscan]
 berachain = { key = "${ETHERSCAN_API_KEY}", chain = 80094, url = "https://api.berascan.com/api" }

--- a/foundry.toml
+++ b/foundry.toml
@@ -17,10 +17,7 @@ remappings = [
     "v2-periphery/=test/invariant/modules/uniswap-v2/v2-periphery/contracts/",
     "uniswap-v2/=test/invariant/modules/uniswap-v2/",
     "solidity-bytes-utils/contracts/=test/invariant/modules/fraxlend/libraries/",
-    "@rari-capital/solmate=node_modules/solmate",
-    "@openzeppelin/contracts@5.0.2/=node_modules/@openzeppelin/contracts-5.0.2/",
-    "@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/",
-    "@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/"
+    "@rari-capital/solmate=node_modules/solmate"
 ]
 [etherscan]
 berachain = { key = "${ETHERSCAN_API_KEY}", chain = 80094, url = "https://api.berascan.com/api" }

--- a/test/StakingVault.t.sol
+++ b/test/StakingVault.t.sol
@@ -64,6 +64,13 @@ contract StakingVaultTest is Test {
         vault.setDepositorsWhitelistDepositAmounts(addrs, caps);
     }
 
+    function _seedLargeDeposit(uint256 amount) internal {
+        _whitelistOne(user1, amount);
+        asset.mint(user1, amount);
+        vm.prank(user1);
+        vault.deposit(amount, user1);
+    }
+
     // ============ Constructor ============
 
     function test_constructor() public view {
@@ -311,6 +318,18 @@ contract StakingVaultTest is Test {
         // 1000 * third / (1000e18 * SCALE) = floor → expect ≈ 333.33e18, floored
         uint256 expectedPrincipal = 1000e18 - (1000e18 * third) / (1000e18 * SCALE);
         assertEq(vault.depositedPrincipal(user1), expectedPrincipal);
+    }
+
+    function test_redeem_largePartial_usesFullPrecisionPrincipalMath() public {
+        uint256 amount = 1e36;
+        _seedLargeDeposit(amount);
+
+        uint256 halfShares = vault.balanceOf(user1) / 2;
+        vm.prank(user1);
+        vault.redeem(halfShares, user1, user1);
+
+        assertEq(vault.depositedPrincipal(user1), amount / 2);
+        assertEq(vault.maxDeposit(user1), amount / 2);
     }
 
     function test_redeem_withAllowance() public {
@@ -636,6 +655,12 @@ contract StakingVaultTest is Test {
         freshVault.acceptOwnership();
         assertEq(freshVault.owner(), user1);
         assertEq(freshVault.pendingOwner(), address(0));
+    }
+
+    function test_RevertWhen_RenounceOwnership() public {
+        vm.prank(owner);
+        vm.expectRevert(StakingVault.StakingVault__RenounceOwnershipDisabled.selector);
+        vault.renounceOwnership();
     }
 
     // ============ Fee-on-transfer guard ============

--- a/test/StakingVault.t.sol
+++ b/test/StakingVault.t.sol
@@ -4,7 +4,10 @@ pragma solidity ^0.8.28;
 import "forge-std/Test.sol";
 import {StakingVault} from "../contracts/utils/StakingVault.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockFeeOnTransferERC20} from "./mocks/MockFeeOnTransferERC20.sol";
+import {MockReentrantERC20, IStakingVaultReentry} from "./mocks/MockReentrantERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 contract StakingVaultTest is Test {
     StakingVault public vault;
@@ -15,12 +18,17 @@ contract StakingVaultTest is Test {
     address public user2;
     address public user3;
 
+    /// @dev `_decimalsOffset() = 6` → 1 asset unit corresponds to SCALE shares.
+    uint256 internal constant SCALE = 10 ** 6;
+
     // Events
-    event DepositorWhitelisted(address indexed depositor, uint256 amount);
+    event DepositorWhitelisted(address indexed depositor, uint256 cap, uint256 currentPrincipal);
     event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
     event Withdraw(
         address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares
     );
+    event Paused(address account);
+    event Unpaused(address account);
 
     function setUp() public {
         owner = makeAddr("owner");
@@ -28,19 +36,17 @@ contract StakingVaultTest is Test {
         user2 = makeAddr("user2");
         user3 = makeAddr("user3");
 
-        // Deploy mock asset
         asset = new MockERC20("Test Token", "TEST");
-
-        // Deploy vault
         vault = new StakingVault(IERC20(address(asset)), "Test Vault", "vTEST");
+        // Ownable2Step: must transfer AND accept
         vault.transferOwnership(owner);
+        vm.prank(owner);
+        vault.acceptOwnership();
 
-        // Fund users
         asset.mint(user1, 10000e18);
         asset.mint(user2, 10000e18);
         asset.mint(user3, 10000e18);
 
-        // Approve vault
         vm.prank(user1);
         asset.approve(address(vault), type(uint256).max);
         vm.prank(user2);
@@ -49,7 +55,16 @@ contract StakingVaultTest is Test {
         asset.approve(address(vault), type(uint256).max);
     }
 
-    // ============ Constructor Tests ============
+    function _whitelistOne(address user, uint256 cap) internal {
+        address[] memory addrs = new address[](1);
+        addrs[0] = user;
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = cap;
+        vm.prank(owner);
+        vault.setDepositorsWhitelistDepositAmounts(addrs, caps);
+    }
+
+    // ============ Constructor ============
 
     function test_constructor() public view {
         assertEq(address(vault.asset()), address(asset));
@@ -58,21 +73,32 @@ contract StakingVaultTest is Test {
         assertEq(vault.owner(), owner);
     }
 
-    // ============ Depositor Whitelist Tests ============
+    function test_decimalsOffset_isSix() public view {
+        // vault.decimals() = asset.decimals() (18) + offset (6) = 24
+        assertEq(vault.decimals(), 24);
+    }
+
+    function test_RevertWhen_ConstructorZeroAsset() public {
+        vm.expectRevert(StakingVault.StakingVault__ZeroAsset.selector);
+        new StakingVault(IERC20(address(0)), "Bad", "BAD");
+    }
+
+    // ============ Whitelist / setDepositorsWhitelistDepositAmounts ============
 
     function test_setDepositorsWhitelistDepositAmounts_single() public {
         address[] memory depositors = new address[](1);
         depositors[0] = user1;
-
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = 1000e18;
 
         vm.prank(owner);
         vm.expectEmit(true, false, false, true);
-        emit DepositorWhitelisted(user1, 1000e18);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
+        emit DepositorWhitelisted(user1, 1000e18, 0);
+        vault.setDepositorsWhitelistDepositAmounts(depositors, caps);
 
-        assertEq(vault.depositWhitelist(user1), 1000e18);
+        assertEq(vault.depositCap(user1), 1000e18);
+        assertEq(vault.depositedPrincipal(user1), 0);
+        assertEq(vault.maxDeposit(user1), 1000e18);
     }
 
     function test_setDepositorsWhitelistDepositAmounts_multiple() public {
@@ -80,415 +106,788 @@ contract StakingVaultTest is Test {
         depositors[0] = user1;
         depositors[1] = user2;
         depositors[2] = user3;
-
-        uint256[] memory depositAmounts = new uint256[](3);
-        depositAmounts[0] = 1000e18;
-        depositAmounts[1] = 2000e18;
-        depositAmounts[2] = 3000e18;
+        uint256[] memory caps = new uint256[](3);
+        caps[0] = 1000e18;
+        caps[1] = 2000e18;
+        caps[2] = 3000e18;
 
         vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
+        vault.setDepositorsWhitelistDepositAmounts(depositors, caps);
 
-        assertEq(vault.depositWhitelist(user1), 1000e18);
-        assertEq(vault.depositWhitelist(user2), 2000e18);
-        assertEq(vault.depositWhitelist(user3), 3000e18);
+        assertEq(vault.depositCap(user1), 1000e18);
+        assertEq(vault.depositCap(user2), 2000e18);
+        assertEq(vault.depositCap(user3), 3000e18);
     }
 
     function test_setDepositorsWhitelistDepositAmounts_canUpdate() public {
-        // Set initial amount
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-        assertEq(vault.depositWhitelist(user1), 1000e18);
-
-        // Update amount
-        depositAmounts[0] = 2000e18;
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-        assertEq(vault.depositWhitelist(user1), 2000e18);
+        _whitelistOne(user1, 1000e18);
+        assertEq(vault.depositCap(user1), 1000e18);
+        _whitelistOne(user1, 2000e18);
+        assertEq(vault.depositCap(user1), 2000e18);
     }
 
     function test_RevertWhen_NonOwnerSetsWhitelist() public {
         address[] memory depositors = new address[](1);
         depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = 1000e18;
 
         vm.prank(user1);
         vm.expectRevert();
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
+        vault.setDepositorsWhitelistDepositAmounts(depositors, caps);
     }
 
     function test_RevertWhen_ArrayLengthMismatch() public {
         address[] memory depositors = new address[](2);
         depositors[0] = user1;
         depositors[1] = user2;
-
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = 1000e18;
 
         vm.prank(owner);
-        vm.expectRevert("Array length mismatch");
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
+        vm.expectRevert(StakingVault.StakingVault__ArrayLengthMismatch.selector);
+        vault.setDepositorsWhitelistDepositAmounts(depositors, caps);
     }
 
-    // ============ Deposit Tests ============
+    function test_RevertWhen_SetCapForZeroAddress() public {
+        address[] memory depositors = new address[](1);
+        depositors[0] = address(0);
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = 1000e18;
+
+        vm.prank(owner);
+        vm.expectRevert(StakingVault.StakingVault__ZeroAddress.selector);
+        vault.setDepositorsWhitelistDepositAmounts(depositors, caps);
+    }
+
+    // ============ Deposit ============
 
     function test_deposit() public {
-        // Whitelist user1
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+        _whitelistOne(user1, 1000e18);
         uint256 depositAmount = 100e18;
 
         vm.prank(user1);
-        vm.expectEmit(true, true, false, true);
-        emit Deposit(user1, user1, depositAmount, depositAmount);
         uint256 shares = vault.deposit(depositAmount, user1);
 
-        assertEq(shares, depositAmount);
-        assertEq(vault.balanceOf(user1), depositAmount);
+        assertEq(shares, depositAmount * SCALE);
+        assertEq(vault.balanceOf(user1), depositAmount * SCALE);
         assertEq(asset.balanceOf(address(vault)), depositAmount);
-        assertEq(vault.depositWhitelist(user1), 900e18); // 1000 - 100
+        assertEq(vault.depositedPrincipal(user1), depositAmount);
+        assertEq(vault.maxDeposit(user1), 900e18);
     }
 
-    function test_deposit_toAnotherReceiver() public {
-        // Whitelist user1
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
-        uint256 depositAmount = 100e18;
-
+    function test_RevertWhen_DepositReceiverMismatch() public {
+        _whitelistOne(user1, 1000e18);
         vm.prank(user1);
-        uint256 shares = vault.deposit(depositAmount, user2);
-
-        assertEq(shares, depositAmount);
-        assertEq(vault.balanceOf(user2), depositAmount);
-        assertEq(vault.depositWhitelist(user1), 900e18);
+        vm.expectRevert(
+            abi.encodeWithSelector(StakingVault.StakingVault__ReceiverMismatch.selector, user1, user2)
+        );
+        vault.deposit(100e18, user2);
     }
 
     function test_deposit_multipleDeposits() public {
-        // Whitelist user1
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
+        _whitelistOne(user1, 1000e18);
 
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
-        // First deposit
         vm.prank(user1);
         vault.deposit(300e18, user1);
-        assertEq(vault.depositWhitelist(user1), 700e18);
+        assertEq(vault.depositedPrincipal(user1), 300e18);
+        assertEq(vault.maxDeposit(user1), 700e18);
 
-        // Second deposit
         vm.prank(user1);
         vault.deposit(200e18, user1);
-        assertEq(vault.depositWhitelist(user1), 500e18);
+        assertEq(vault.depositedPrincipal(user1), 500e18);
+        assertEq(vault.maxDeposit(user1), 500e18);
 
-        assertEq(vault.balanceOf(user1), 500e18);
+        assertEq(vault.balanceOf(user1), 500e18 * SCALE);
     }
 
-    function test_RevertWhen_DepositExceedsWhitelist() public {
-        // Whitelist user1 with small amount
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 50e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+    function test_deposit_exactlyMaxDeposit_succeeds() public {
+        _whitelistOne(user1, 1000e18);
+        uint256 cap = vault.maxDeposit(user1);
         vm.prank(user1);
-        vm.expectRevert(); // Underflow when trying to subtract more than available
+        uint256 shares = vault.deposit(cap, user1);
+        assertEq(shares, cap * SCALE);
+        assertEq(vault.depositedPrincipal(user1), cap);
+        assertEq(vault.maxDeposit(user1), 0);
+    }
+
+    /// @dev F-5 (code-review): super.mint internally checks `shares > maxMint(receiver)`. With
+    ///      our override `maxMint = previewDeposit(maxDeposit)`, the boundary case
+    ///      `mint(maxMint(user), user)` must NOT spuriously revert — locks in the floor/ceil
+    ///      round-trip safety proof from the contract NatSpec.
+    function test_mint_exactlyMaxMint_succeeds() public {
+        _whitelistOne(user1, 1000e18);
+        uint256 maxShares = vault.maxMint(user1);
+        assertGt(maxShares, 0);
+        vm.prank(user1);
+        uint256 assets = vault.mint(maxShares, user1);
+        assertGt(assets, 0);
+        // After consuming all of maxMint, no room left
+        assertEq(vault.maxMint(user1), 0);
+        assertEq(vault.maxDeposit(user1), 0);
+    }
+
+    function test_RevertWhen_DepositExceedsCap() public {
+        _whitelistOne(user1, 50e18);
+        vm.prank(user1);
+        // OZ ERC4626 reverts with ERC4626ExceededMaxDeposit via super's check
+        vm.expectRevert();
         vault.deposit(100e18, user1);
     }
 
     function test_RevertWhen_DepositWithoutWhitelist() public {
         vm.prank(user1);
-        vm.expectRevert(); // Underflow when whitelist amount is 0
+        vm.expectRevert();
         vault.deposit(100e18, user1);
     }
 
-    // ============ Mint Tests ============
+    // ============ Mint ============
 
     function test_mint() public {
-        // Whitelist user1
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
-        uint256 sharesToMint = 100e18;
-
+        _whitelistOne(user1, 1000e18);
+        uint256 sharesToMint = 100e18 * SCALE; // 100 assets worth of shares
         vm.prank(user1);
         uint256 assets = vault.mint(sharesToMint, user1);
 
-        assertEq(assets, sharesToMint); // 1:1 initially
+        assertEq(assets, 100e18);
         assertEq(vault.balanceOf(user1), sharesToMint);
+        assertEq(vault.depositedPrincipal(user1), 100e18);
+        assertEq(vault.maxDeposit(user1), 900e18);
     }
 
-    // ============ Redeem Tests ============
+    function test_RevertWhen_MintReceiverMismatch() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vm.expectRevert(
+            abi.encodeWithSelector(StakingVault.StakingVault__ReceiverMismatch.selector, user1, user2)
+        );
+        vault.mint(100e18 * SCALE, user2);
+    }
+
+    // ============ Redeem ============
 
     function test_redeem() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+        _whitelistOne(user1, 1000e18);
         vm.prank(user1);
         vault.deposit(1000e18, user1);
+        assertEq(vault.maxDeposit(user1), 0);
 
-        assertEq(vault.depositWhitelist(user1), 0); // All used up
-
-        // Redeem half
-        uint256 sharesToRedeem = 500e18;
+        uint256 sharesToRedeem = 500e18 * SCALE;
         vm.prank(user1);
         uint256 assets = vault.redeem(sharesToRedeem, user1, user1);
 
         assertEq(assets, 500e18);
-        assertEq(vault.balanceOf(user1), 500e18);
-        assertEq(vault.depositWhitelist(user1), 500e18); // Replenished
-        assertEq(asset.balanceOf(user1), 9500e18); // 10000 - 1000 + 500
+        assertEq(vault.balanceOf(user1), 500e18 * SCALE);
+        assertEq(vault.depositedPrincipal(user1), 500e18);
+        assertEq(vault.maxDeposit(user1), 500e18);
+        assertEq(asset.balanceOf(user1), 9500e18);
     }
 
     function test_redeem_full() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+        _whitelistOne(user1, 1000e18);
         vm.prank(user1);
         vault.deposit(1000e18, user1);
 
-        // Redeem all
         vm.prank(user1);
-        uint256 assets = vault.redeem(1000e18, user1, user1);
+        uint256 assets = vault.redeem(1000e18 * SCALE, user1, user1);
 
         assertEq(assets, 1000e18);
         assertEq(vault.balanceOf(user1), 0);
-        assertEq(vault.depositWhitelist(user1), 1000e18); // Fully replenished
-        assertEq(asset.balanceOf(user1), 10000e18); // Back to starting balance
+        assertEq(vault.depositedPrincipal(user1), 0);
+        assertEq(vault.maxDeposit(user1), 1000e18);
+        assertEq(asset.balanceOf(user1), 10000e18);
     }
 
-    function test_redeem_withApproval() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+    function test_redeem_restoresPrincipal_proportional() public {
+        _whitelistOne(user1, 1000e18);
         vm.prank(user1);
         vault.deposit(1000e18, user1);
 
-        // User1 approves user2
+        // Redeem a third of shares: principalOut = 1000 * (shares/3) / shares = ~333
+        uint256 third = (1000e18 * SCALE) / 3;
         vm.prank(user1);
-        vault.approve(user2, 500e18);
+        vault.redeem(third, user1, user1);
 
-        // User2 redeems on behalf of user1
+        // 1000 * third / (1000e18 * SCALE) = floor → expect ≈ 333.33e18, floored
+        uint256 expectedPrincipal = 1000e18 - (1000e18 * third) / (1000e18 * SCALE);
+        assertEq(vault.depositedPrincipal(user1), expectedPrincipal);
+    }
+
+    function test_redeem_withAllowance() public {
+        // user1 deposits, user2 redeems via allowance to user3
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+
+        vm.prank(user1);
+        vault.approve(user2, 500e18 * SCALE);
+
         vm.prank(user2);
-        uint256 assets = vault.redeem(500e18, user2, user1);
+        uint256 assets = vault.redeem(500e18 * SCALE, user3, user1);
 
         assertEq(assets, 500e18);
-        assertEq(vault.balanceOf(user1), 500e18);
-        assertEq(asset.balanceOf(user2), 10500e18); // Got the redeemed assets
-        assertEq(vault.depositWhitelist(user1), 500e18); // Replenished
+        assertEq(vault.balanceOf(user1), 500e18 * SCALE);
+        // Principal credit goes to user1 (the share owner), not user2 (the caller)
+        assertEq(vault.depositedPrincipal(user1), 500e18);
+        // user2 (caller) did not consume any of their own cap
+        assertEq(vault.depositedPrincipal(user2), 0);
+        // user3 (receiver) gets the assets
+        assertEq(asset.balanceOf(user3), 10500e18);
     }
 
-    // ============ Withdraw Tests ============
+    // ============ Withdraw ============
 
     function test_withdraw() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+        _whitelistOne(user1, 1000e18);
         vm.prank(user1);
         vault.deposit(1000e18, user1);
 
-        // Withdraw
         vm.prank(user1);
         uint256 shares = vault.withdraw(500e18, user1, user1);
 
-        assertEq(shares, 500e18);
-        assertEq(vault.balanceOf(user1), 500e18);
-        assertEq(vault.depositWhitelist(user1), 500e18); // Replenished
+        assertEq(shares, 500e18 * SCALE);
+        assertEq(vault.balanceOf(user1), 500e18 * SCALE);
+        assertEq(vault.depositedPrincipal(user1), 500e18);
+        assertEq(vault.maxDeposit(user1), 500e18);
+        // CRITICAL: withdraw returns EXACTLY the requested assets (audit F-3 fix)
+        assertEq(asset.balanceOf(user1), 9500e18);
     }
 
-    // ============ Multiple Users Tests ============
+    function test_RevertWhen_WithdrawExceedsBalance() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(500e18, user1);
 
-    function test_multipleUsers_independentWhitelists() public {
-        // Setup two users
-        address[] memory depositors = new address[](2);
-        depositors[0] = user1;
-        depositors[1] = user2;
-        uint256[] memory depositAmounts = new uint256[](2);
-        depositAmounts[0] = 1000e18;
-        depositAmounts[1] = 500e18;
+        vm.prank(user1);
+        vm.expectRevert();
+        vault.withdraw(600e18, user1, user1);
+    }
 
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
+    // ============ F-1 regression: cap does not grow after yield ============
 
-        // User1 deposits
+    function test_cap_doesNotGrow_afterYield_fullRedeem() public {
+        _whitelistOne(user1, 1000e18);
         vm.prank(user1);
         vault.deposit(1000e18, user1);
-        assertEq(vault.depositWhitelist(user1), 0);
 
-        // User2 deposits
+        // Team reimburses by direct transfer
+        asset.mint(address(vault), 500e18);
+        assertEq(vault.totalAssets(), 1500e18);
+
+        // User1 redeems all shares
+        uint256 balance = vault.balanceOf(user1);
+        vm.prank(user1);
+        uint256 assets = vault.redeem(balance, user1, user1);
+
+        // User receives more assets than originally deposited (yield delivered)
+        assertGt(assets, 1000e18);
+        assertApproxEqAbs(assets, 1500e18, 1e12); // dust from virtual shares offset
+
+        // CRITICAL: principal fully restored to 0; cap NOT inflated
+        assertEq(vault.depositedPrincipal(user1), 0);
+        assertEq(vault.maxDeposit(user1), 1000e18); // exact original cap, not 1500
+    }
+
+    function test_cap_doesNotGrow_afterYield_partialRedeem() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+
+        asset.mint(address(vault), 500e18);
+
+        uint256 balance = vault.balanceOf(user1);
+        uint256 half = balance / 2;
+        vm.prank(user1);
+        uint256 assets = vault.redeem(half, user1, user1);
+
+        // User receives ~750 assets (half of 1500 totalAssets at share price 1.5)
+        assertGt(assets, 500e18);
+        // Principal halved (proportional to shares burned)
+        assertEq(vault.depositedPrincipal(user1), 500e18);
+        // maxDeposit allows depositing 500 more — total cap consumption stays 1000
+        assertEq(vault.maxDeposit(user1), 500e18);
+    }
+
+    function test_cap_doesNotGrow_afterYield_multiplePartials() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+        asset.mint(address(vault), 500e18);
+
+        uint256 balance = vault.balanceOf(user1);
+        // Redeem in thirds (approximately)
+        uint256 third = balance / 3;
+        vm.prank(user1);
+        vault.redeem(third, user1, user1);
+        vm.prank(user1);
+        vault.redeem(third, user1, user1);
+        // Final: redeem remaining balance to force exact-zero principal
+        uint256 remaining = vault.balanceOf(user1);
+        vm.prank(user1);
+        vault.redeem(remaining, user1, user1);
+
+        // After full redemption via partials: principal exactly 0, cap fully restored
+        assertEq(vault.depositedPrincipal(user1), 0);
+        assertEq(vault.maxDeposit(user1), 1000e18);
+    }
+
+    /// @dev F-6 (code-review): Post-yield, tiny redeems whose principalOut floors to 0 leave
+    ///      principal "stuck" above 0 (dust). A subsequent full-balance redeem resets it.
+    ///      Documents the acceptable QoS noted in `redeem`'s NatSpec — and guards against a
+    ///      future change that breaks the reset-on-full-redeem property.
+    function test_dustAccumulation_resolvedByFullRedeem() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+        // Yield → share price > 1
+        asset.mint(address(vault), 500e18);
+
+        uint256 dustIterations = 50;
+        uint256 dustShares = 1; // 1 wei of share, far below the principal-flooring threshold
+
+        for (uint256 i = 0; i < dustIterations; i++) {
+            vm.prank(user1);
+            vault.redeem(dustShares, user1, user1);
+        }
+
+        // Principal is stuck at 1000 because each tiny redeem floored principalOut to 0
+        assertEq(vault.depositedPrincipal(user1), 1000e18);
+        // Balance has dropped by the dust burns
+        assertEq(vault.balanceOf(user1), 1000e18 * SCALE - dustIterations);
+
+        // Full-balance redeem resets principal cleanly
+        uint256 remaining = vault.balanceOf(user1);
+        vm.prank(user1);
+        vault.redeem(remaining, user1, user1);
+        assertEq(vault.depositedPrincipal(user1), 0);
+        assertEq(vault.maxDeposit(user1), 1000e18);
+    }
+
+    function test_redeem_redeposit_neverExceedsCap() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+        asset.mint(address(vault), 500e18);
+
+        uint256 balance = vault.balanceOf(user1);
+        vm.prank(user1);
+        vault.redeem(balance / 2, user1, user1);
+        assertEq(vault.depositedPrincipal(user1), 500e18);
+
+        // Re-deposit the freed cap
+        vm.prank(user1);
+        vault.deposit(500e18, user1);
+        assertEq(vault.depositedPrincipal(user1), 1000e18);
+        assertLe(vault.depositedPrincipal(user1), vault.depositCap(user1));
+    }
+
+    function test_maxDeposit_saturatesAtZero_whenCapLoweredBelowPrincipal() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(800e18, user1);
+
+        // Owner lowers cap below current principal
+        _whitelistOne(user1, 500e18);
+
+        assertEq(vault.depositedPrincipal(user1), 800e18); // unchanged
+        assertEq(vault.depositCap(user1), 500e18);
+        assertEq(vault.maxDeposit(user1), 0); // saturates
+    }
+
+    // ============ Soulbound shares ============
+
+    function test_RevertWhen_ShareTransfer() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+
+        vm.prank(user1);
+        vm.expectRevert(StakingVault.StakingVault__NonTransferable.selector);
+        vault.transfer(user2, 100);
+    }
+
+    function test_RevertWhen_ShareTransferFrom() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+
+        vm.prank(user1);
+        vault.approve(user2, 100);
+
+        vm.prank(user2);
+        vm.expectRevert(StakingVault.StakingVault__NonTransferable.selector);
+        vault.transferFrom(user1, user3, 100);
+    }
+
+    function test_approve_emitsEvent_but_transferFrom_reverts() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+
+        vm.prank(user1);
+        vault.approve(user2, 100);
+        assertEq(vault.allowance(user1, user2), 100);
+
+        // transferFrom reverts even though allowance is set
+        vm.prank(user2);
+        vm.expectRevert(StakingVault.StakingVault__NonTransferable.selector);
+        vault.transferFrom(user1, user3, 50);
+    }
+
+    // ============ Pausable ============
+
+    function test_pause_blocksDeposit() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(user1);
+        vm.expectRevert(); // OZ EnforcedPause
+        vault.deposit(100e18, user1);
+    }
+
+    function test_pause_blocksMint() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(user1);
+        vm.expectRevert();
+        vault.mint(100e18 * SCALE, user1);
+    }
+
+    function test_pause_allowsRedeem() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+
+        vm.prank(owner);
+        vault.pause();
+
+        // Redeem succeeds even while paused
+        vm.prank(user1);
+        uint256 assets = vault.redeem(500e18 * SCALE, user1, user1);
+        assertEq(assets, 500e18);
+    }
+
+    function test_pause_allowsWithdraw() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(user1);
+        vault.deposit(1000e18, user1);
+
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(user1);
+        uint256 shares = vault.withdraw(500e18, user1, user1);
+        assertEq(shares, 500e18 * SCALE);
+    }
+
+    function test_pauseAndUnpause_cycleAllowsDepositAgain() public {
+        _whitelistOne(user1, 1000e18);
+        vm.prank(owner);
+        vault.pause();
+        vm.prank(owner);
+        vault.unpause();
+
+        vm.prank(user1);
+        uint256 shares = vault.deposit(100e18, user1);
+        assertEq(shares, 100e18 * SCALE);
+    }
+
+    function test_RevertWhen_NonOwnerPauses() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        vault.pause();
+    }
+
+    function test_maxDeposit_returnsZero_whenPaused() public {
+        _whitelistOne(user1, 1000e18);
+        assertEq(vault.maxDeposit(user1), 1000e18);
+
+        vm.prank(owner);
+        vault.pause();
+        assertEq(vault.maxDeposit(user1), 0);
+    }
+
+    function test_maxMint_returnsZero_whenPaused() public {
+        _whitelistOne(user1, 1000e18);
+        assertGt(vault.maxMint(user1), 0);
+
+        vm.prank(owner);
+        vault.pause();
+        assertEq(vault.maxMint(user1), 0);
+    }
+
+    // ============ Ownable2Step ============
+
+    function test_Ownable2Step_pendingOwnerBeforeAccept() public {
+        // Start a fresh vault to test the pre-accept state directly
+        StakingVault freshVault = new StakingVault(IERC20(address(asset)), "X", "X");
+        // Deployer is `this` (the test contract)
+        assertEq(freshVault.owner(), address(this));
+
+        freshVault.transferOwnership(user1);
+        // Owner is still deployer until acceptance
+        assertEq(freshVault.owner(), address(this));
+        assertEq(freshVault.pendingOwner(), user1);
+
+        vm.prank(user1);
+        freshVault.acceptOwnership();
+        assertEq(freshVault.owner(), user1);
+        assertEq(freshVault.pendingOwner(), address(0));
+    }
+
+    // ============ Fee-on-transfer guard ============
+
+    function test_RevertWhen_FeeOnTransferAsset_deposit() public {
+        MockFeeOnTransferERC20 fotAsset = new MockFeeOnTransferERC20("FOT", "FOT");
+        StakingVault fotVault = new StakingVault(IERC20(address(fotAsset)), "FOT-V", "FOT-V");
+        fotVault.transferOwnership(owner);
+        vm.prank(owner);
+        fotVault.acceptOwnership();
+
+        fotAsset.mint(user1, 1000e18);
+        vm.prank(user1);
+        fotAsset.approve(address(fotVault), type(uint256).max);
+
+        address[] memory addrs = new address[](1);
+        addrs[0] = user1;
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = 1000e18;
+        vm.prank(owner);
+        fotVault.setDepositorsWhitelistDepositAmounts(addrs, caps);
+
+        vm.prank(user1);
+        vm.expectRevert(StakingVault.StakingVault__FeeOnTransferNotSupported.selector);
+        fotVault.deposit(100e18, user1);
+    }
+
+    function test_RevertWhen_FeeOnTransferAsset_mint() public {
+        MockFeeOnTransferERC20 fotAsset = new MockFeeOnTransferERC20("FOT", "FOT");
+        StakingVault fotVault = new StakingVault(IERC20(address(fotAsset)), "FOT-V", "FOT-V");
+        fotVault.transferOwnership(owner);
+        vm.prank(owner);
+        fotVault.acceptOwnership();
+
+        fotAsset.mint(user1, 1000e18);
+        vm.prank(user1);
+        fotAsset.approve(address(fotVault), type(uint256).max);
+
+        address[] memory addrs = new address[](1);
+        addrs[0] = user1;
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = 1000e18;
+        vm.prank(owner);
+        fotVault.setDepositorsWhitelistDepositAmounts(addrs, caps);
+
+        vm.prank(user1);
+        vm.expectRevert(StakingVault.StakingVault__FeeOnTransferNotSupported.selector);
+        fotVault.mint(100e18 * SCALE, user1);
+    }
+
+    // ============ Reentrancy guard ============
+    //
+    // Coverage requirement: `nonReentrant` must be present on all four entry points
+    // (deposit, mint, redeem, withdraw). Each test below uses one of the four as the
+    // OUTER call. The mock asset's transferFrom (deposit/mint) or transfer (redeem/withdraw)
+    // callback reenters `deposit` (any nonReentrant target works). If any outer entry point
+    // loses `nonReentrant`, its test would no longer revert with ReentrancyGuardReentrantCall.
+
+    /// @dev Bootstraps a fresh vault + reentrant-asset + whitelisted user1 with a 500-asset
+    ///      seeded deposit (so user1 has shares for redeem/withdraw outer-call tests).
+    function _setupReentrancyHarness() internal returns (StakingVault reVault, MockReentrantERC20 reAsset) {
+        reAsset = new MockReentrantERC20("RE", "RE");
+        reVault = new StakingVault(IERC20(address(reAsset)), "RE-V", "RE-V");
+        reVault.transferOwnership(owner);
+        vm.prank(owner);
+        reVault.acceptOwnership();
+
+        reAsset.mint(user1, 10000e18);
+        vm.prank(user1);
+        reAsset.approve(address(reVault), type(uint256).max);
+
+        address[] memory addrs = new address[](1);
+        addrs[0] = user1;
+        uint256[] memory caps = new uint256[](1);
+        caps[0] = 1000e18;
+        vm.prank(owner);
+        reVault.setDepositorsWhitelistDepositAmounts(addrs, caps);
+
+        // Seed a deposit so user1 has shares for redeem/withdraw outer calls
+        vm.prank(user1);
+        reVault.deposit(500e18, user1);
+    }
+
+    function test_RevertWhen_ReentrantCall_outerDeposit() public {
+        (StakingVault reVault, MockReentrantERC20 reAsset) = _setupReentrancyHarness();
+
+        reAsset.arm(
+            IStakingVaultReentry(address(reVault)),
+            MockReentrantERC20.Mode.ReenterDeposit,
+            10e18,
+            user1
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        reVault.deposit(100e18, user1);
+    }
+
+    function test_RevertWhen_ReentrantCall_outerMint() public {
+        (StakingVault reVault, MockReentrantERC20 reAsset) = _setupReentrancyHarness();
+
+        reAsset.arm(
+            IStakingVaultReentry(address(reVault)),
+            MockReentrantERC20.Mode.ReenterDeposit,
+            10e18,
+            user1
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        reVault.mint(100e18 * SCALE, user1);
+    }
+
+    function test_RevertWhen_ReentrantCall_outerRedeem() public {
+        (StakingVault reVault, MockReentrantERC20 reAsset) = _setupReentrancyHarness();
+
+        // Reenter deposit from the asset's transfer callback (outer = redeem → safeTransfer)
+        reAsset.arm(
+            IStakingVaultReentry(address(reVault)),
+            MockReentrantERC20.Mode.ReenterDeposit,
+            10e18,
+            user1
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        reVault.redeem(100e18 * SCALE, user1, user1);
+    }
+
+    function test_RevertWhen_ReentrantCall_outerWithdraw() public {
+        (StakingVault reVault, MockReentrantERC20 reAsset) = _setupReentrancyHarness();
+
+        reAsset.arm(
+            IStakingVaultReentry(address(reVault)),
+            MockReentrantERC20.Mode.ReenterDeposit,
+            10e18,
+            user1
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        reVault.withdraw(100e18, user1, user1);
+    }
+
+    /// @dev Sanity check that the mock actually reenters when armed (otherwise the four
+    ///      tests above could pass for the wrong reason — they'd revert because the
+    ///      callback fails, not because nonReentrant fires).
+    function test_reentrantMock_armingActuallyTriggersReentry() public {
+        (StakingVault reVault, MockReentrantERC20 reAsset) = _setupReentrancyHarness();
+
+        // Arm to reenter MINT (different target from deposit) so we can confirm the
+        // ReentrancyGuardReentrantCall selector matches even when target != outer.
+        reAsset.arm(
+            IStakingVaultReentry(address(reVault)),
+            MockReentrantERC20.Mode.ReenterMint,
+            10e18 * SCALE,
+            user1
+        );
+
+        vm.prank(user1);
+        vm.expectRevert(ReentrancyGuard.ReentrancyGuardReentrantCall.selector);
+        reVault.deposit(100e18, user1);
+    }
+
+    // ============ Underfunded vault: proportional distribution ============
+
+    function test_underfundedVault_proportionalDistribution() public {
+        // Two users each whitelisted for 500
+        _whitelistOne(user1, 500e18);
+        _whitelistOne(user2, 500e18);
+
+        vm.prank(user1);
+        vault.deposit(500e18, user1);
         vm.prank(user2);
         vault.deposit(500e18, user2);
-        assertEq(vault.depositWhitelist(user2), 0);
+        assertEq(vault.totalAssets(), 1000e18);
 
-        // User1 redeems
+        // Simulate asset loss: half the assets vanish from the vault (e.g., rebase, hack, etc.)
+        asset.burn(address(vault), 500e18);
+        assertEq(vault.totalAssets(), 500e18);
+
+        uint256 user1AssetBefore = asset.balanceOf(user1);
+        uint256 user2AssetBefore = asset.balanceOf(user2);
+        uint256 user1Shares = vault.balanceOf(user1);
+        uint256 user2Shares = vault.balanceOf(user2);
+
+        // Each user redeems all their shares
         vm.prank(user1);
-        vault.redeem(500e18, user1, user1);
-        assertEq(vault.depositWhitelist(user1), 500e18);
-
-        // User2's whitelist unchanged
-        assertEq(vault.depositWhitelist(user2), 0);
-
-        // User2 redeems
+        vault.redeem(user1Shares, user1, user1);
         vm.prank(user2);
-        vault.redeem(250e18, user2, user2);
-        assertEq(vault.depositWhitelist(user2), 250e18);
+        vault.redeem(user2Shares, user2, user2);
 
-        // User1's whitelist unchanged from previous
-        assertEq(vault.depositWhitelist(user1), 500e18);
+        uint256 user1Received = asset.balanceOf(user1) - user1AssetBefore;
+        uint256 user2Received = asset.balanceOf(user2) - user2AssetBefore;
+
+        // Each receives ~250 (proportional split of 500 between equal shareholders)
+        assertApproxEqAbs(user1Received, 250e18, 1e12);
+        assertApproxEqAbs(user2Received, 250e18, 1e12);
+
+        // Critical: BOTH users' principal restored to 0 — cap-room decouples from asset loss
+        assertEq(vault.depositedPrincipal(user1), 0);
+        assertEq(vault.depositedPrincipal(user2), 0);
+        assertEq(vault.maxDeposit(user1), 500e18);
+        assertEq(vault.maxDeposit(user2), 500e18);
     }
 
-    // ============ Standard ERC4626 Tests ============
+    // ============ Standard ERC4626 / view ============
 
-    function test_previewFunctions() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
+    function test_maxFunctions_zeroBeforeWhitelist() public view {
+        // F-4 fix: maxDeposit reflects actual capacity (0 before whitelist)
+        assertEq(vault.maxDeposit(user1), 0);
+        assertEq(vault.maxMint(user1), 0);
+        assertEq(vault.maxWithdraw(user1), 0);
+        assertEq(vault.maxRedeem(user1), 0);
+    }
 
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+    function test_maxDeposit_reflectsRemainingCap() public {
+        _whitelistOne(user1, 1000e18);
+        assertEq(vault.maxDeposit(user1), 1000e18);
         vm.prank(user1);
-        vault.deposit(1000e18, user1);
-
-        // Preview functions should work
-        uint256 previewDeposit = vault.previewDeposit(100e18);
-        assertGt(previewDeposit, 0);
-
-        uint256 previewMint = vault.previewMint(100e18);
-        assertGt(previewMint, 0);
-
-        uint256 previewWithdraw = vault.previewWithdraw(100e18);
-        assertGt(previewWithdraw, 0);
-
-        uint256 previewRedeem = vault.previewRedeem(100e18);
-        assertGt(previewRedeem, 0);
-    }
-
-    function test_maxFunctions() public view {
-        // Max functions should return reasonable values
-        assertEq(vault.maxDeposit(user1), type(uint256).max);
-        assertEq(vault.maxMint(user1), type(uint256).max);
-        assertEq(vault.maxWithdraw(user1), 0); // No deposits yet
-        assertEq(vault.maxRedeem(user1), 0); // No deposits yet
+        vault.deposit(300e18, user1);
+        assertEq(vault.maxDeposit(user1), 700e18);
     }
 
     function test_totalAssets() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
-
+        _whitelistOne(user1, 1000e18);
         assertEq(vault.totalAssets(), 0);
-
         vm.prank(user1);
         vault.deposit(1000e18, user1);
         assertEq(vault.totalAssets(), 1000e18);
 
-        // If someone sends tokens directly, totalAssets should increase
         asset.mint(address(vault), 100e18);
         assertEq(vault.totalAssets(), 1100e18);
     }
 
-    function test_convertToShares_and_convertToAssets() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 2000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
+    function test_multipleUsers_independentCaps() public {
+        _whitelistOne(user1, 1000e18);
+        _whitelistOne(user2, 500e18);
 
         vm.prank(user1);
         vault.deposit(1000e18, user1);
+        assertEq(vault.maxDeposit(user1), 0);
 
-        // Initially 1:1
-        assertEq(vault.convertToShares(1000e18), 1000e18);
-        assertEq(vault.convertToAssets(1000e18), 1000e18);
-
-        // If yield is added (e.g., direct transfer), share price increases
-        asset.mint(address(vault), 100e18);
-
-        // 1100 assets / 1000 shares = 1.1 assets per share
-        assertApproxEqAbs(vault.convertToAssets(1000e18), 1100e18, 1);
-        // To get 1000 assets, need ~909 shares (1000 / 1.1)
-        assertApproxEqAbs(vault.convertToShares(1000e18), 909090909090909090909, 1e15);
-    }
-
-    function test_RevertWhen_WithdrawExceedsBalance() public {
-        // Whitelist and deposit
-        address[] memory depositors = new address[](1);
-        depositors[0] = user1;
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = 1000e18;
-
-        vm.prank(owner);
-        vault.setDepositorsWhitelistDepositAmounts(depositors, depositAmounts);
+        vm.prank(user2);
+        vault.deposit(500e18, user2);
+        assertEq(vault.maxDeposit(user2), 0);
 
         vm.prank(user1);
-        vault.deposit(500e18, user1);
+        vault.redeem(500e18 * SCALE, user1, user1);
+        assertEq(vault.maxDeposit(user1), 500e18);
 
-        // Try to withdraw more than deposited
-        vm.prank(user1);
-        vm.expectRevert();
-        vault.withdraw(600e18, user1, user1);
+        // user2's cap unchanged
+        assertEq(vault.maxDeposit(user2), 0);
     }
 }

--- a/test/mocks/MockFeeOnTransferERC20.sol
+++ b/test/mocks/MockFeeOnTransferERC20.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC20 that takes a 5% fee on transferFrom, used to verify StakingVault's FoT guard.
+contract MockFeeOnTransferERC20 is ERC20 {
+    uint256 public feeNumerator = 5;
+    uint256 public constant FEE_DENOMINATOR = 100;
+
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        uint256 fee = (amount * feeNumerator) / FEE_DENOMINATOR;
+        uint256 sendAmount = amount - fee;
+        _spendAllowance(from, _msgSender(), amount);
+        _transfer(from, to, sendAmount);
+        if (fee > 0) {
+            _transfer(from, address(this), fee);
+        }
+        return true;
+    }
+}

--- a/test/mocks/MockReentrantERC20.sol
+++ b/test/mocks/MockReentrantERC20.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IStakingVaultReentry {
+    function deposit(uint256 assets, address receiver) external returns (uint256);
+    function mint(uint256 shares, address receiver) external returns (uint256);
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256);
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256);
+}
+
+/// @notice ERC20 that reenters the target vault during `transfer` / `transferFrom`, used to verify
+///         `nonReentrant` is present on every StakingVault entry point.
+contract MockReentrantERC20 is ERC20 {
+    enum Mode { None, ReenterDeposit, ReenterMint, ReenterRedeem, ReenterWithdraw }
+
+    Mode public mode;
+    IStakingVaultReentry public vault;
+    uint256 public reentrantAmount;
+    address public reentrantOwner;
+    bool private _reentrancyArmed;
+
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function arm(IStakingVaultReentry _vault, Mode _mode, uint256 _amount, address _owner) external {
+        vault = _vault;
+        mode = _mode;
+        reentrantAmount = _amount;
+        reentrantOwner = _owner;
+        _reentrancyArmed = true;
+    }
+
+    function _maybeReenter() internal {
+        if (!_reentrancyArmed) return;
+        _reentrancyArmed = false; // single-shot
+        if (mode == Mode.ReenterDeposit) {
+            vault.deposit(reentrantAmount, reentrantOwner);
+        } else if (mode == Mode.ReenterMint) {
+            vault.mint(reentrantAmount, reentrantOwner);
+        } else if (mode == Mode.ReenterRedeem) {
+            vault.redeem(reentrantAmount, reentrantOwner, reentrantOwner);
+        } else if (mode == Mode.ReenterWithdraw) {
+            vault.withdraw(reentrantAmount, reentrantOwner, reentrantOwner);
+        }
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        bool ok = super.transfer(to, amount);
+        _maybeReenter();
+        return ok;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        bool ok = super.transferFrom(from, to, amount);
+        _maybeReenter();
+        return ok;
+    }
+}


### PR DESCRIPTION
# StakingVault: audit-driven refactor

Closes all 14 audit findings on `contracts/utils/StakingVault.sol` and rewrites the contract under a coherent design model. 54 / 54 tests pass.

## Background

The pre-refactor contract (`contracts/utils/StakingVault.sol`, 109 lines) was a whitelisted ERC4626 reimbursement vault. The team uses it for a one-time deal: a curated set of whitelisted depositors put in an asset token, the team later directly transfers more of the asset to the vault (raising share price for existing holders), and depositors withdraw more than they put in.

An audit found:
- **1 Critical** — the cap silently grew with yield. A user whitelisted for 1000 could end up with effective cap > 1000 after a redeem-post-yield because the contract credited `depositWhitelist[owner] += assetsReceived` rather than `depositWhitelist[owner] += principalRedeemed`.
- **2 High** — (a) shares were freely ERC20-transferable, so a whitelisted user could transfer shares to an arbitrary address, which would *gain* a cap allowance on redeem; (b) `withdraw(N)` would transfer *more* than N assets back due to a rounding mismatch between the override and the parent.
- **5 Medium + 4 Low + 4 Informational** — `maxDeposit`/`maxMint` returning `type(uint256).max` despite the cap (spec violation), missing reentrancy guards, missing events, `Ownable` vs `Ownable2Step`, underflow-as-access-control, etc.

## Design decisions

### Non-transferable (soulbound) shares — and why this is the right choice

The audit's High-severity F-2 was: *the whitelist cap is transferable to non-whitelisted addresses via share transfer + redeem*. Three approaches were considered:

**(A) Track principal proportionally across transfers.** Override `_update` to move `depositedPrincipal[from] * value / balanceOf(from)` from sender to receiver. Preserves ERC20 transferability. Requires a recipient cap check (`require(depositCap[to] > 0)`) to prevent capacity laundering to unwhitelisted addresses. *Complex.* The proportional-move math has edge cases (full-balance transfers, dust accumulation, transfers that drop the recipient over their cap, transfers from someone whose cap has since been lowered). Each edge case is a potential bug.

**(B) Allow ERC20 transfer freely; restrict `redeem`/`withdraw` to whitelisted callers only.** Non-whitelisted holders can't extract value, so the bug is gated. *But this only closes F-2 partially.* Capacity can still slosh between whitelisted users (one whitelisted user transfers shares to another whitelisted user, recipient redeems → recipient's `depositWhitelist[]` grows). And it doesn't fix the underlying F-1 (cap-grows-with-yield) bug — that's the formula, not the gate.

**(C) Soulbound shares — disallow all transfers between non-zero addresses.** ERC20 `transfer` and `transferFrom` revert. Only mint (from `address(0)`) and burn (to `address(0)`) are permitted. This collapses the problem: only whitelisted addresses can ever hold shares (the only entry path is `deposit`/`mint`, both whitelist-gated); F-2 becomes structurally impossible. No principal-on-transfer accounting is needed.

**Why (C) wins for this contract:**

1. **Transfers are not a use case here.** This is a one-time reimbursement for a curated set of whitelisted depositors. No router, no aggregator, no DeFi composition. The cost of restricting transfers is zero in practice.

2. **(A)'s accounting complexity creates new attack surface.** Every edge case is a fresh potential bug. Plan-review v1 already caught two Criticals on the simpler design (mutation-before-super reentrancy; post-super read of mutated `balanceOf`); the transfer-accounting variant would have multiplied the review surface.

3. **(B) is structurally incomplete.** It restricts who can *call* redeem but not who can *receive shares from* a whitelisted user. F-2 reduces but doesn't disappear. Capacity arbitrage between whitelisted users remains.

4. **(C) preserves operational flexibility where it matters.** Critically, **soulbound does NOT break the `approve` → `redeem`-on-behalf flow**:
   - `approve(spender, amount)` still works — `approve` mutates only the allowance mapping, never calls `_update`.
   - `vault.redeem(shares, receiver, owner)` from a spender other than `owner` still works — internally super.redeem calls `_spendAllowance(owner, spender, shares)` (allowance check, no transfer) then `_burn(owner, shares)` → `_update(owner, address(0), shares)`. The `to == address(0)` exemption in our soulbound override allows the burn through.
   - This means: if the team or a relayer needs to redeem on a user's behalf (e.g., to recover stuck principal, batch-redeem the depositor set), they can — the user just `approve`s them first. Same operational power as a normal ERC4626, *without* the F-2 hole.
   - What `transferFrom` *does* lose: routing shares through a third party. But routing shares is exactly what F-2 exploited, so losing it is the point.

5. **Wallet/explorer concerns are negligible.** No user is checking their soulbound share balance in MetaMask for trading purposes; the asset of interest is the underlying reimbursement token.

**Code:** `_update` override at [StakingVault.sol:212-215](contracts/contracts/utils/StakingVault.sol#L212-L215). One conditional, one revert. Documented in NatSpec at [:208-211](contracts/contracts/utils/StakingVault.sol#L208-L211).

### Snapshot-pre-super pattern for redeem / withdraw

This is the second non-obvious design decision. The principal-refund formula on `redeem` is:

```
principalOut = depositedPrincipal[owner] * sharesRedeemed / balanceOf(owner)
```

The naive implementation reads `balanceOf(owner)` directly. **This is broken.** `super.redeem` internally calls `_burn(owner, shares)` → `_update(owner, address(0), shares)`, which decrements `balanceOf(owner)` by `shares` *before* our formula runs. So a naive override reading `balanceOf(owner)` after `super.redeem` returns sees the *post-burn* balance:

- **Full redeem** (`shares == balance`): post-burn `balanceOf(owner) == 0` → division by zero → **transaction reverts on every full redeem (DoS).**
- **Partial redeem** (say 500 of 1000 shares): post-burn `balanceOf(owner) == 500` → `principalOut = principal * 500 / 500 = principal` (the *entire* principal). User has burned only half their shares but the cap counter drains to 0 — exact opposite of the audit-recommended behavior.

Both failure modes were flagged by plan-review (v2 cycle) before any code was written.

**The fix:** snapshot `principalBefore` and `balanceBefore` BEFORE calling `super.redeem`/`super.withdraw`, then use the snapshots in the formula. The pre-burn balance is the correct divisor. Implementation: [StakingVault.sol:154-170](contracts/contracts/utils/StakingVault.sol#L154-L170) (redeem) and [:180-195](contracts/contracts/utils/StakingVault.sol#L180-L195) (withdraw).

### Other decisions

- **`Ownable2Step` instead of single-step `Ownable`** (divergence from sibling contracts in `contracts/`). Rationale: this vault holds user reimbursement funds with no team-side recovery path; an accidental `transferOwnership` typo would brick the owner role permanently. Worth the divergence here; sibling migration is independently scoped.
- **`_decimalsOffset() = 6`** as the first-depositor inflation defence. Raises attacker cost by ~10⁶×. Side effect: vault share decimals = `asset.decimals() + 6` (e.g., USDC asset → vault has 12 decimals; WETH asset → 24 decimals). Acceptable for the closed-system use case.
- **Fee-on-transfer guard** on `deposit`/`mint` via balance-delta check. If a hypothetical operator picks a FoT asset by accident, the vault refuses to accept it rather than silently misaccounting.
- **`Pausable`** for `deposit`/`mint` only. Exits (`redeem`/`withdraw`) remain available at the vault layer even when paused — incident response shouldn't trap user funds.
- **Custom errors with parameters** instead of short-string `require`. Divergence from sibling convention; justified by audit F-12 which specifically called out the need for parameterized revert data for liveness/UX (vs. silent arithmetic-underflow panics).
- **`receiver == msg.sender` enforced on `deposit`/`mint`**. Since shares are soulbound, sending shares to an arbitrary `receiver` would strand them where the depositor cannot redeem them.

## Audit findings closed

| ID | Severity | Resolution |
|---|---|---|
| F-1 | Critical | Cap-doesn't-grow: tracks `depositedPrincipal` separately, refunds proportionally on redeem ([StakingVault.sol:158-167](contracts/contracts/utils/StakingVault.sol#L158-L167)). |
| F-2 | High | Non-transferable shares via `_update` override ([:212-215](contracts/contracts/utils/StakingVault.sol#L212-L215)). |
| F-3 | High | `withdraw` calls `super.withdraw` (preserves exact-assets-out contract) instead of routing through `redeem` ([:180-195](contracts/contracts/utils/StakingVault.sol#L180-L195)). |
| F-4 | High | `maxDeposit`/`maxMint` overrides reflect remaining cap and `paused()` ([:199-209](contracts/contracts/utils/StakingVault.sol#L199-L209)). |
| F-5 (act/recv mismatch) | Medium | `receiver == msg.sender` required on deposit/mint. |
| F-6 (inflation) | Medium | `_decimalsOffset() = 6` ([:201-203](contracts/contracts/utils/StakingVault.sol#L201-L203)). |
| F-7 (events) | Medium | `DepositorWhitelisted` event emitted on every cap-related state change (set, deposit, mint, redeem, withdraw). |
| F-8 (redeem override bypasses maxRedeem) | Medium | Calls `super.redeem` instead of inlining `_burn` + `safeTransfer`. |
| F-9 (Ownable2Step) | Medium | Switched to `Ownable2Step`. |
| F-10 (reentrancy) | Medium | `nonReentrant` on all four entry points. |
| F-11 (owner zero-out) | Low → Medium | `Pausable` added as the operator's incident-response lever. |
| F-12 (underflow as error) | Low | Named custom errors throughout; OZ's `ERC4626ExceededMaxDeposit` for cap-exceed cases. |
| F-13 (zero address) | Low | `setDepositorsWhitelistDepositAmounts` reverts on zero address. |
| F-14 (zero asset) | Low | Constructor rejects `address(0)` asset. |
| F-15 (NatSpec mismatches) | Info | All NatSpec rewritten to match actual behavior. |

## Other improvements (not from the audit)

- **Fee-on-transfer asset guard** — balance-delta check in deposit/mint.
- **Snapshot-pre-super pattern** — see "Design decisions" above. Two Criticals caught in plan-review.

## Verification

- **Plan-review: 3 rounds.** v1 caught the mutation-before-super reentrancy class + missing `paused()` in max functions. v2 caught the post-super `balanceOf` read causing div-by-zero + over-credit. v3: READY.
- **Code-review: 1 round.** 3 Medium/Low findings (all non-blocking; integrator-facing concerns irrelevant to a closed depositor set). Defensive test-coverage findings (extend reentrancy harness to all 4 entry points; add maxMint round-trip test; add dust-accumulation test) all applied.
- **Tests: 54 / 54 pass.** Forge build clean.

Test coverage highlights:
- F-1 regression tests: full redeem after yield, partial redeem after yield, multiple partials summing to full, redeem-then-redeposit-never-exceeds-cap.
- Reentrancy: tests for every entry point as the outer call, plus a sanity check that the mock actually reenters.
- Underfunded vault: proportional distribution + cap-room decouples from asset loss.
- Soulbound: direct transfer reverts, transferFrom reverts, allowance still works (allowance + redeem-on-behalf flow preserved).
- Pause: blocks deposit/mint, allows redeem/withdraw.
- Ownable2Step: pending-owner state before acceptance.
- Fee-on-transfer asset rejected on deposit and mint.

## Out of scope

- **Sibling-contract migration** to `Ownable2Step` / custom errors / similar conventions. StakingVault is the only freshly-authored contract here; siblings keep their existing conventions.
- **Factory.** No `StakingVaultFactory` in this PR. The contract is deployed directly. If a factory is ever added, note that `Ownable2Step` makes the sibling-factory `transferOwnership(owner())` handoff pattern (used by `LendingAssetVaultFactory.sol` and `AutoCompoundingPodLpFactory.sol`) broken-by-default — `transferOwnership` only sets `pendingOwner`, and the destination must call `acceptOwnership()` separately.
- **Wallet/explorer integration** for 24-decimal share tokens (WETH-asset case). Acceptable for the closed system.

## Files changed

- `contracts/utils/StakingVault.sol` — full rewrite (109 → 216 lines)
- `test/StakingVault.t.sol` — full rewrite (494 → 850 lines, 54 tests)
- `test/mocks/MockFeeOnTransferERC20.sol` — new mock for FoT guard tests
- `test/mocks/MockReentrantERC20.sol` — new mock for reentrancy tests (extended to cover all 4 entry points)
- `foundry.toml` — 3 added OZ remappings to resolve chainlink-ccip's pinned `@openzeppelin/contracts@5.0.2/` import (was blocking `forge build`)
